### PR TITLE
Add Resilience4j circuit breaker to NotificationClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target
 
 # IDE Files
 .idea
+/.apt_generated/
+/.apt_generated_tests/

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <version>3.1.4</version>
         </dependency>
 
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-spring-boot2</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
     </dependencies>
 
 	<dependencyManagement>

--- a/src/main/java/com/microservice/authservice/config/SecurityConfig.java
+++ b/src/main/java/com/microservice/authservice/config/SecurityConfig.java
@@ -63,8 +63,7 @@ public class SecurityConfig {
 
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
-		return (web) -> web.ignoring().antMatchers("/authenticate/signup", "/authenticate/login",
-				"/authenticate/refreshtoken");
+		return (web) -> web.ignoring().antMatchers("/authenticate/signup", "/authenticate/login", "/authenticate/refreshtoken");
 	}
 
 	@Bean

--- a/src/main/java/com/microservice/authservice/config/feign/NotificationClient.java
+++ b/src/main/java/com/microservice/authservice/config/feign/NotificationClient.java
@@ -1,15 +1,27 @@
 package com.microservice.authservice.config.feign;
 
-
-import com.microservice.authservice.dto.NotificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import com.microservice.authservice.dto.NotificationRequest;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
 @FeignClient("notification-service")
 public interface NotificationClient {
+	
+	Logger log = LoggerFactory.getLogger(NotificationClient.class);
 
-    @PostMapping("/notification/action")
-    void notifyAction(@RequestBody NotificationRequest request);
+	@CircuitBreaker(name = "notifyActionCB", fallbackMethod = "notifyActionFallback")
+	@PostMapping("/notification/action")
+	void notifyAction(@RequestBody NotificationRequest request);
+
+	default void notifyActionFallback(Exception ex) {
+		log.error("Notifcation Service - notify action failed.");
+		log.error(ex.getMessage());
+	}
 
 }


### PR DESCRIPTION
Integrated Resilience4j by adding the 'resilience4j-spring-boot2' dependency and applying a circuit breaker to the NotificationClient's notifyAction method with a fallback.